### PR TITLE
Add plot style utility

### DIFF
--- a/scripts/plot_style.py
+++ b/scripts/plot_style.py
@@ -1,0 +1,21 @@
+"""Utility to set a consistent plot style for matplotlib/Seaborn plots."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def set_plot_style() -> None:
+    """Apply a simple, clean aesthetic for plots.
+
+    This configures Seaborn and matplotlib to use a whitegrid style,
+    a pleasant default color palette, and removes the top and right
+    spines for clarity.
+    """
+    sns.set_theme(context="notebook", style="whitegrid", palette="Set2", font_scale=1.2)
+    plt.rcParams["axes.spines.top"] = False
+    plt.rcParams["axes.spines.right"] = False
+
+
+__all__ = ["set_plot_style"]


### PR DESCRIPTION
## Summary
- provide a `set_plot_style` helper that configures matplotlib & seaborn

## Testing
- `python -m py_compile scripts/plot_style.py`


------
https://chatgpt.com/codex/tasks/task_e_6889507eaf5c832aa936ed9a0b556e95