### PR TITLE
Add Quarto deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Render Quarto and Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: quarto-dev/quarto-actions/setup@v2
+      - name: Render site
+        run: quarto render
+      - name: Draft tweet thread
+        if: env.OPENAI_API_KEY != ''
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          ABSTRACT=$(grep -m1 '^abstract:' index.qmd | cut -d ':' -f2- | xargs || true)
+          if [ -z "$ABSTRACT" ]; then
+            echo "No abstract found; skipping tweet thread generation." && exit 0
+          fi
+          echo "Calling OpenAI API..."
+          curl https://api.openai.com/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $OPENAI_API_KEY" \
+            -d '{
+              "model": "gpt-3.5-turbo",
+              "messages": [
+                {"role": "system", "content": "Create a short tweet thread summarizing the following abstract."},
+                {"role": "user", "content": "'$ABSTRACT'"}
+              ]
+            }' > tweet-thread.json
+          echo "Tweet thread saved to tweet-thread.json"
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _site
+          token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-### README.md
+# Accumultor Series
+
+This repository holds the source for a Quarto project.
+
+## Continuous deployment
+
+A GitHub Actions workflow renders the site on every push to `main` and deploys
+it to GitHub Pages from the `gh-pages` branch. If an `OPENAI_API_KEY` secret is
+present, the workflow also calls the OpenAI API to generate a tweet thread based
+on the article's abstract.


### PR DESCRIPTION
## Summary
- document CI setup
- add GitHub Actions workflow to build Quarto, deploy to GitHub Pages and optionally call OpenAI API

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688952bee1a0832a807ea9a3b19e6f60